### PR TITLE
Add --oauth-token option to allow oauth token authentication

### DIFF
--- a/bin/github-commit-status-updater
+++ b/bin/github-commit-status-updater
@@ -9,6 +9,7 @@ class GithubCommitStatusUpdater < Thor
   method_option :sha1, :type => :string, :required => true, :aliases => "-s"
   method_option :username, :type => :string, :aliases => "-u"
   method_option :password, :type => :string, :aliases => "-p"
+  method_option :oauth_token, :type => :string
   desc "success", "commit status success"
   def success
     client.create_status(options.repo, options.sha1, "success")
@@ -21,6 +22,7 @@ class GithubCommitStatusUpdater < Thor
   method_option :sha1, :type => :string, :required => true, :aliases => "-s"
   method_option :username, :type => :string, :aliases => "-u"
   method_option :password, :type => :string, :aliases => "-p"
+  method_option :oauth_token, :type => :string
   desc "failure", "commit status failure"
   def failure
     client.create_status(options.repo, options.sha1, "failure")
@@ -33,6 +35,8 @@ class GithubCommitStatusUpdater < Thor
   def client
     if options.username && options.password
       Octokit::Client.new(:login => options.username, :password => options.password)
+    elsif options.username && options.oauth_token
+      Octokit::Client.new(:login => options.username, :oauth_token => options.oauth_token)
     else
       Octokit::Client.new
     end


### PR DESCRIPTION
In my case, I don't want to write plain text password at Jenkins's configuration textarea.
GitHub's Repo Status API (and octokit) allows oauth token authentication, so I added `--oauth-token` option.

In addition, oauth token can restrict permission by scopes.
If `--oauth-token` option is accepted, the users of github-commit-status-updater can choose more secure authentication mechanism using `repo:status` scope.

Usage:

```
$ ./bin/github-commit-status-updater success -r kyanny/test -s 17e993377f82a6dd02fe92111d1b7d68de26a333 -u kyanny --oauth-token=(masked)
status success
```

Example pull request: https://github.com/kyanny/test/pull/2
