### PR TITLE
Add command line option to specify "context" parameter

### DIFF
--- a/bin/github-commit-status-updater
+++ b/bin/github-commit-status-updater
@@ -16,6 +16,7 @@ class GithubCommitStatusUpdater < Thor
     method_option :target_url, :type => :string
     method_option :description, :type => :string
     method_option :web_endpoint, :type => :string
+    method_option :context, :type => :string
 
     desc "#{method}", "commit status #{method}"
     define_method "#{method}" do
@@ -26,7 +27,14 @@ class GithubCommitStatusUpdater < Thor
             c.web_endpoint = options.web_endpoint
           end
         end
-        client.create_status(options.repo, options.sha1, method, {target_url: options.target_url, description: options.description})
+
+        status_options = {
+          target_url: options.target_url,
+          description: options.description,
+          context: options.context
+        }
+
+        client.create_status(options.repo, options.sha1, method, status_options)
         puts "Changed status as #{method}"
       rescue Octokit::Error => e
         abort "Update error: #{e.message}"


### PR DESCRIPTION
The [create status API request](https://developer.github.com/v3/repos/statuses/#create-a-status)
accepts a `context` parameter too.

The value of this param is used to diversify the sources that added the status,
and is displayed next to the status image.

Usage:

```
github-commit-status-updater success \
  --repo=mokagio/github-commit-status-updater \
  --sha1=99f50d24d39156147510d613fc29c2cf904a9458 \
  --username=mokagio \
  --oauth-token=$token \
  --description="testing adding a success status to commit" \
  --context="mokagio/test"
```

Results:

![screen shot 2016-02-05 at 2 05 44 pm](https://cloud.githubusercontent.com/assets/1218433/12836988/0083e88c-cc12-11e5-8083-4447c928f303.png)
